### PR TITLE
Add PR_SET_NO_NEW_PRIVS to generated constants

### DIFF
--- a/defs_constants_linux.go
+++ b/defs_constants_linux.go
@@ -26,6 +26,10 @@ package seccomp
 // #include <stdlib.h>
 import "C"
 
+// prSetNoNewPrivs defines the prctl flag to set the calling thread's
+// no_new_privs bit.
+const prSetNoNewPrivs = C.PR_SET_NO_NEW_PRIVS
+
 // Valid operations for seccomp syscall.
 // https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/seccomp.h#L14-L17
 const (

--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -29,7 +29,7 @@ import (
 // SetNoNewPrivs will use prctl to set the calling thread's no_new_privs bit to
 // 1 (true). Once set, this bit cannot be unset.
 func SetNoNewPrivs() error {
-	return prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
+	return prctl(prSetNoNewPrivs, 1)
 }
 
 // LoadFilter will install seccomp using native methods.

--- a/zconstants.go
+++ b/zconstants.go
@@ -20,6 +20,8 @@
 
 package seccomp
 
+const prSetNoNewPrivs = 0x26
+
 const (
 	seccompSetModeFilter = 0x1
 )


### PR DESCRIPTION
The PR_SET_NO_NEW_PRIVS constant is not defined in all of the golang.org/x/sys/unix architecture files. So use our own constant.