### PR TITLE
Return ENOSYS when X32 syscalls are used on X86_64

### DIFF
--- a/defs_constants_linux.go
+++ b/defs_constants_linux.go
@@ -57,7 +57,10 @@ const (
 	ActionAllow       Action = C.SECCOMP_RET_ALLOW        // Allow.
 )
 
-const errnoEPERM = C.EPERM
+const (
+	errnoEPERM  = C.EPERM
+	errnoENOSYS = C.ENOSYS
+)
 
 // List of SECCOMP_SET_MODE_FILTER values.
 // https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/seccomp.h#L19-L21

--- a/filter_test.go
+++ b/filter_test.go
@@ -50,6 +50,8 @@ type SeccompTest struct {
 }
 
 func simulateSyscalls(t testing.TB, policy *Policy, tests []SeccompTest) {
+	t.Helper()
+
 	filter, err := policy.Assemble()
 	if err != nil {
 		t.Fatal(err)
@@ -110,6 +112,12 @@ func TestPolicyAssembleBlacklist(t *testing.T) {
 		{
 			SeccompData{NR: 4, Arch: uint32(arch.ARM.ID)},
 			ActionAllow,
+		},
+		{
+			// Attempts to bypass the filter by using X32 syscalls on X86_64
+			// are met with ENOSYS.
+			SeccompData{NR: int32(arch.X32.SyscallNames["execve"] + arch.X32.SeccompMask), Arch: uint32(arch.X86_64.ID)},
+			ActionErrno | Action(errnoENOSYS),
 		},
 	})
 }

--- a/zconstants.go
+++ b/zconstants.go
@@ -38,7 +38,10 @@ const (
 	ActionAllow       Action = 0x7fff0000
 )
 
-const errnoEPERM = 0x1
+const (
+	errnoEPERM  = 0x1
+	errnoENOSYS = 0x26
+)
 
 const (
 	FilterFlagTSync FilterFlag = 0x1


### PR DESCRIPTION
This prevents a program from bypassing the filter by using the X32 ABI on X86_64.

In the BPF program below, instructions 3 and 4 are new with this change.

```
0: ld [4]
1: jneq #3221225534,6
2: ld [0]              # Load syscall number.
3: jlt #1073741824,1   # if syscall number > X32_SYSCALL_BIT
4: ret #327718         # return ENOSYS
5: jeq #59,1
6: jneq #57,1
7: ret #0
8: ret #2147418112
```

Closes #5