### PR TITLE
Add Supported function to test availability of seccomp

### DIFF
--- a/defs_constants_linux.go
+++ b/defs_constants_linux.go
@@ -33,6 +33,11 @@ const prSetNoNewPrivs = C.PR_SET_NO_NEW_PRIVS
 // Valid operations for seccomp syscall.
 // https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/seccomp.h#L14-L17
 const (
+	// Seccomp filter mode where only system calls that the calling thread is
+	// permitted to make are read(2), write(2), _exit(2) (but not
+	// exit_group(2)), and sigreturn(2). Flags must be 0.
+	seccompSetModeStrict = C.SECCOMP_SET_MODE_STRICT
+
 	// Seccomp filter mode where a BPF filter defines what system calls are
 	// allowed.
 	seccompSetModeFilter = C.SECCOMP_SET_MODE_FILTER

--- a/seccomp_linux.go
+++ b/seccomp_linux.go
@@ -26,6 +26,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Supported returns true if the seccomp syscall is supported.
+func Supported() bool {
+	// Strict mode requires that flags be set to 0, but we are sending 1 so
+	// this will return EINVAL if the syscall exists and is allowed.
+	if err := seccomp(seccompSetModeStrict, 1, nil); err == syscall.EINVAL {
+		return true
+	}
+
+	return false
+}
+
 // SetNoNewPrivs will use prctl to set the calling thread's no_new_privs bit to
 // 1 (true). Once set, this bit cannot be unset.
 func SetNoNewPrivs() error {

--- a/seccomp_linux_test.go
+++ b/seccomp_linux_test.go
@@ -34,6 +34,10 @@ import (
 )
 
 func TestLoadFilter(t *testing.T) {
+	if !Supported() {
+		t.Skip("seccomp not supported by kernel")
+	}
+
 	var policy Policy
 
 	switch runtime.GOARCH {

--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -19,6 +19,13 @@
 
 package seccomp
 
+// Supported returns true if the seccomp syscall is supported.
+//
+// This is a stub for non-Linux systems. It always returns false.
+func Supported() bool {
+	return false
+}
+
 // SetNoNewPrivs will use prctl to set the calling thread's no_new_privs bit to
 // 1 (true). Once set, this bit cannot be unset.
 //

--- a/zconstants.go
+++ b/zconstants.go
@@ -23,6 +23,8 @@ package seccomp
 const prSetNoNewPrivs = 0x26
 
 const (
+	seccompSetModeStrict = 0
+
 	seccompSetModeFilter = 0x1
 )
 


### PR DESCRIPTION
The `seccomp.Supported()` function can be used to test if seccomp is supported
by the kernel prior to calling `LoadFilter`.