### PR TITLE
Fix integer overflow in BPF conditional jumps

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -161,7 +161,6 @@ func TestPolicyAssembleWhitelist(t *testing.T) {
 }
 
 func TestPolicyAssembleLongList(t *testing.T) {
-
 	// Sort syscall numbers to make manual review of filters with -dump easier.
 	syscallNumbers := make([]int, 0, len(arch.X86_64.SyscallNumbers))
 	for nr := range arch.X86_64.SyscallNumbers {


### PR DESCRIPTION
If the list of syscalls is too long (>256) then the library sends incorrect
BPF code and this results in crashes, because some syscalls are denied. This
commit fixes the crash by splitting the list of syscalls into groups of
size 256 in Policy.Assemble. Also I found another similar overflow in
SyscallGroup.Assemble and fixed it as well.