### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ program is generated based on a filter policy created by you.
 ###### Features
 
 - Pure Go and does not have a libseccomp dependency.
-- Filters are customizable and can be written a whitelist or blacklist.
+- Filters are customizable and can be written as an allowlist or blocklist.
 - Uses `SECCOMP_FILTER_FLAG_TSYNC` to sync the filter to all threads created by
   the Go runtime.
 - Invokes `prctl(PR_SET_NO_NEW_PRIVS, 1)` to set the threads `no_new_privs` bit
   which is generally required before loading a seccomp filter.
 - [seccomp-profiler](./cmd/seccomp-profiler) tool for automatically generating
-  a whitelist policy based on the system calls that a binary uses.
+  a allowlist policy based on the system calls that a binary uses.
 
 ###### Limitations
 

--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -30,12 +30,12 @@ import (
 
 var (
 	policyFile string
-	noNewPrivs bool
+	allowNewPrivs bool
 )
 
 func main() {
 	flag.StringVar(&policyFile, "policy", "seccomp.yml", "seccomp policy file")
-	flag.BoolVar(&noNewPrivs, "no-new-privs", true, "set no new privs bit")
+	flag.BoolVar(&allowNewPrivs, "allow-new-privs", false, "do not set no new privs bit")
 	flag.Parse()
 
 	args := flag.Args()
@@ -53,7 +53,7 @@ func main() {
 
 	// Create a filter based on config.
 	filter := seccomp.Filter{
-		NoNewPrivs: noNewPrivs,
+		NoNewPrivs: !allowNewPrivs,
 		Flag:       seccomp.FilterFlagTSync,
 		Policy:     *policy,
 	}

--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -30,12 +30,12 @@ import (
 
 var (
 	policyFile string
-	allowNewPrivs bool
+	noNewPrivs bool
 )
 
 func main() {
 	flag.StringVar(&policyFile, "policy", "seccomp.yml", "seccomp policy file")
-	flag.BoolVar(&allowNewPrivs, "allow-new-privs", false, "do not set no new privs bit")
+	flag.BoolVar(&noNewPrivs, "no-new-privs", true, "set no new privs bit")
 	flag.Parse()
 
 	args := flag.Args()
@@ -53,7 +53,7 @@ func main() {
 
 	// Create a filter based on config.
 	filter := seccomp.Filter{
-		NoNewPrivs: !allowNewPrivs,
+		NoNewPrivs: noNewPrivs,
 		Flag:       seccomp.FilterFlagTSync,
 		Policy:     *policy,
 	}

--- a/cmd/seccomp-profiler/README.md
+++ b/cmd/seccomp-profiler/README.md
@@ -1,10 +1,10 @@
 # seccomp-profiler
 
 seccomp-profiler reads Go binaries compiled for Linux (amd64 and 386 only) to
-determine what system calls it uses. Then it generates a whitelist seccomp
+determine what system calls it uses. Then it generates an allowlist seccomp
 profile for the binary.
 
-It can output the whitelist as either Go code or YAML (by using `-format=code`
+It can output the allowlist as either Go code or YAML (by using `-format=code`
 or `-format=config`).
 
 ## Usage
@@ -25,7 +25,7 @@ $ seccomp-profiler metricbeat > seccomp_linux_amd64.go
 2018/05/01 11:49:58 Found 93 unique syscalls
 ```
 
-This will write seccomp policy that whitelists the system calls found in the
+This will write a seccomp policy that allows the system calls found in the
 binary's object code.
 
 ```go


### PR DESCRIPTION
~Unless I'm mistaken, there is no way to not set no-new-privs currently.~

I was mistaken - per https://github.com/elastic/go-seccomp-bpf/pull/17#discussion_r719515064 boolean flags can take a value, so `-no-new-privs=false` works