### PR TITLE
Updated syscall tables for Linux v6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated syscall tables for Linux v6.5 to add cachestat.
+
 ### Deprecated
 
 ### Removed

--- a/arch/mk_syscalls_linux.go
+++ b/arch/mk_syscalls_linux.go
@@ -394,7 +394,7 @@ var (
 
 func init() {
 	flag.StringVar(&outputFile, "out", "zsyscalls.go", "output file")
-	flag.StringVar(&linuxVersion, "version", "v6.0", "linux version (git tag)")
+	flag.StringVar(&linuxVersion, "version", "v6.5", "linux version (git tag)")
 }
 
 func main() {

--- a/arch/zsyscalls.go
+++ b/arch/zsyscalls.go
@@ -19,7 +19,7 @@
 
 package arch
 
-// Based on Linux v6.0.
+// Based on Linux v6.5.
 
 var syscallsARM = map[int]string{
 	0:      "restart_syscall",
@@ -425,6 +425,7 @@ var syscallsARM = map[int]string{
 	448:    "process_mrelease",
 	449:    "futex_waitv",
 	450:    "set_mempolicy_home_node",
+	451:    "cachestat",
 	983041: "breakpoint",
 	983042: "cacheflush",
 	983043: "usr26",
@@ -761,6 +762,7 @@ var syscallsAARCH64 = map[int]string{
 	448: "process_mrelease",
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
+	451: "cachestat",
 }
 
 var syscalls386 = map[int]string{
@@ -1204,6 +1206,7 @@ var syscalls386 = map[int]string{
 	448: "process_mrelease",
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
+	451: "cachestat",
 }
 
 var syscallsX32 = map[int]string{
@@ -1569,6 +1572,7 @@ var syscallsX32 = map[int]string{
 	448: "process_mrelease",
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
+	451: "cachestat",
 	512: "rt_sigaction",
 	513: "rt_sigreturn",
 	514: "ioctl",
@@ -1970,4 +1974,5 @@ var syscallsX86_64 = map[int]string{
 	448: "process_mrelease",
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
+	451: "cachestat",
 }


### PR DESCRIPTION
This change mostly adds the new cachestat syscall.