### PR TITLE
Implement System Call Argument Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ program is generated based on a filter policy created by you.
 
 - Pure Go and does not have a libseccomp dependency.
 - Filters are customizable and can be written as an allowlist or blocklist.
+- Supports system call argument filtering.
 - Uses `SECCOMP_FILTER_FLAG_TSYNC` to sync the filter to all threads created by
   the Go runtime.
 - Invokes `prctl(PR_SET_NO_NEW_PRIVS, 1)` to set the threads `no_new_privs` bit
@@ -40,8 +41,6 @@ program is generated based on a filter policy created by you.
 
 ###### Limitations
 
-- System call argument filtering is not implemented. (Pull requests are
-  welcomed. See #1.)
 - System call tables are only implemented for 386, amd64, arm and arm64.
   (More system call table generation code should be added to
   [arch/mk_syscalls_linux.go](./arch/mk_syscalls_linux.go).)

--- a/assembler.go
+++ b/assembler.go
@@ -141,7 +141,6 @@ func (p *Program) NewLabel() Label {
 // Assemble resolves all jump destinations to concrete instructions using the labels.
 // This method takes care of long jumps and resolves them by using early returns or unconditional long jumps.
 func (p *Program) Assemble() ([]bpf.Instruction, error) {
-
 	for _, jump := range p.jumps {
 		jumpInst := p.instructions[jump.index].(bpf.JumpIf)
 

--- a/assembler.go
+++ b/assembler.go
@@ -73,7 +73,7 @@ type Program struct {
 	nextLabel    Label
 }
 
-// NewProgram initializes an empty program.
+// NewProgram returns an initialized empty program.
 func NewProgram() Program {
 	return Program{
 		instructions: make([]bpf.Instruction, 0),

--- a/assembler.go
+++ b/assembler.go
@@ -76,8 +76,6 @@ type Program struct {
 // NewProgram returns an initialized empty program.
 func NewProgram() Program {
 	return Program{
-		instructions: make([]bpf.Instruction, 0),
-		jumps:        make([]Jump, 0),
 		labels:       make(map[Label][]Index),
 		nextLabel:    Label(1),
 	}

--- a/assembler.go
+++ b/assembler.go
@@ -1,0 +1,244 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package seccomp
+
+import (
+	"encoding/binary"
+	"unsafe"
+
+	"golang.org/x/net/bpf"
+)
+
+const (
+	argumentOffset = 16
+)
+
+var nativeEndian binary.ByteOrder
+
+func init() {
+	buf := [2]byte{}
+	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
+
+	switch buf {
+	case [2]byte{0xCD, 0xAB}:
+		nativeEndian = binary.LittleEndian
+	case [2]byte{0xAB, 0xCD}:
+		nativeEndian = binary.BigEndian
+	default:
+		panic("Could not determine native endianness.")
+	}
+}
+
+// Label marks a jump destination in the instruction list of the Program.
+type Label int
+
+// Index is the concrete index of an instruction in the instruction list.
+type Index int
+
+// Jump jumps conditionally to the true or the false label.
+// The concrete condition is not relevant to resolve the jumps.
+type Jump struct {
+	index      Index
+	trueLabel  Label
+	falseLabel Label
+}
+
+// The Program consists of a list of bpf.Instructions.
+// Conditional jumps can point to different labels in the program and must be resolved by calling ResolveJumps.
+//
+// NewLabel creates a new label that can be used as jump destination.
+//
+// SetLabel must be used to specify the concrete instruction.
+// Only forward jumps are supported; this means a label must not be used after setting it.
+type Program struct {
+	instructions []bpf.Instruction
+	jumps        []Jump
+	labels       map[Label][]Index
+	nextLabel    Label
+}
+
+// NewProgram initializes an empty program.
+func NewProgram() Program {
+	return Program{
+		instructions: make([]bpf.Instruction, 0),
+		jumps:        make([]Jump, 0),
+		labels:       make(map[Label][]Index),
+		nextLabel:    Label(1),
+	}
+}
+
+// JmpIfTrue inserts a conditional jump.
+// If the condition is true, it jumps to the given label.
+// If it is false, the program flow continues with the next instruction.
+func (p *Program) JmpIfTrue(cond bpf.JumpTest, val uint32, trueLabel Label) {
+	nextInst := p.NewLabel()
+	p.JmpIf(cond, val, trueLabel, nextInst)
+	p.SetLabel(nextInst)
+}
+
+// JmpIf inserts a conditional jump.
+// If the condition is true, it jumps to the true label.
+// If it is false, it jumps to the false label.
+func (p *Program) JmpIf(cond bpf.JumpTest, val uint32, trueLabel Label, falseLabel Label) {
+	p.jumps = append(p.jumps, Jump{index: p.currentIndex(), trueLabel: trueLabel, falseLabel: falseLabel})
+
+	inst := bpf.JumpIf{Cond: cond, Val: val}
+	p.instructions = append(p.instructions, inst)
+}
+
+// SetLabel sets the label to the latest instruction.
+func (p *Program) SetLabel(label Label) {
+	index := p.currentIndex()
+	p.labels[label] = append(p.labels[label], index)
+}
+
+// Ret inserts a return instruction.
+func (p *Program) Ret(action Action) {
+	if action == ActionErrno {
+		action |= Action(errnoEPERM)
+	}
+	p.instructions = append(p.instructions, bpf.RetConstant{Val: uint32(action)})
+}
+
+// LdHi inserts an instruction to load the most significant 32-bit of the 64-bit argument.
+func (p *Program) LdHi(arg int) {
+	offset := uint32(argumentOffset + 8*arg)
+	if nativeEndian == binary.LittleEndian {
+		offset += 4
+	}
+	p.instructions = append(p.instructions, bpf.LoadAbsolute{Off: offset, Size: 4})
+}
+
+// LdLo inserts an instruction to load the least significant 32-bit of the 64-bit argument.
+func (p *Program) LdLo(arg int) {
+	offset := uint32(argumentOffset + 8*arg)
+	if nativeEndian == binary.BigEndian {
+		offset += 4
+	}
+	p.instructions = append(p.instructions, bpf.LoadAbsolute{Off: offset, Size: 4})
+}
+
+// NewLabel creates a new label. It must be used with SetLabel.
+func (p *Program) NewLabel() Label {
+	p.nextLabel++
+	return p.nextLabel
+}
+
+// Assemble resolves all jump destinations to concrete instructions using the labels.
+// This method takes care of long jumps and resolves them by using early returns or unconditional long jumps.
+func (p *Program) Assemble() []bpf.Instruction {
+
+	for _, jump := range p.jumps {
+		jumpInst := p.instructions[jump.index].(bpf.JumpIf)
+
+		jumpInst.SkipTrue = uint8(p.resolveLabel(jump, jump.trueLabel))
+		jumpInst.SkipFalse = uint8(p.resolveLabel(jump, jump.falseLabel))
+
+		p.instructions[jump.index] = jumpInst
+	}
+
+	return p.instructions
+}
+
+// resolveLabel resolves the label to a short jump.
+func (p *Program) resolveLabel(jump Jump, label Label) int {
+	dest := p.labels[label]
+	skipN := p.computeSkipN(jump, label)
+
+	if skipN < 0 {
+		// Jumping backwards is not supported, use the next destination.
+		// This happens when a new instruction was added to support long jumps,
+		//therefore, another destination must be available.
+		dest = dest[1:]
+		p.labels[label] = dest
+		skipN = p.computeSkipN(jump, label)
+	}
+
+	if skipN > 255 {
+		insertAfter := findInsertAfter(p.jumps, jump)
+
+		// If the jump destination is a return instruction, copy it and add an early return,
+		// if not, insert a long jump.
+		jumpDest := p.instructions[dest[0]]
+		if _, ok := jumpDest.(bpf.RetConstant); !ok {
+			jumpDest = bpf.Jump{Skip: uint32(skipN - int(insertAfter.index))}
+		}
+
+		insertIndex := p.insertAfter(insertAfter.index, jumpDest)
+		p.labels[label] = append([]Index{insertIndex}, dest...)
+		skipN = p.computeSkipN(jump, label)
+	}
+	return skipN
+}
+
+// Inserts the instruction after the instruction indicated by index.
+func (p *Program) insertAfter(index Index, inst bpf.Instruction) Index {
+	jumpInst := p.instructions[index].(bpf.JumpIf)
+	p.instructions[index] = jumpInst
+
+	index++
+	p.instructions = append(p.instructions[:index+1], p.instructions[index:]...)
+	p.instructions[index] = inst
+	p.updateIndices(index)
+	return index
+}
+
+// After inserting a new instruction into the instruction list, the indices are wrong.
+// This method updates all indices after the instruction point.
+func (p *Program) updateIndices(after Index) {
+	for i := range p.jumps {
+		if p.jumps[i].index >= after {
+			p.jumps[i].index++
+		}
+	}
+
+	for _, v := range p.labels {
+		for i := range v {
+			if v[i] >= after {
+				v[i]++
+			}
+		}
+	}
+}
+
+// Computes the number of instructions to skip by resolving the label.
+// It might be that the jump is a long jump.
+func (p *Program) computeSkipN(jump Jump, label Label) int {
+	dest := p.labels[label]
+	return int(dest[0]-jump.index) - 1
+}
+
+// To insert a new instruction into the instruction list, the furthest jump instruction within
+// a short jump is searched.
+// It is necessary to search a jump instruction to jump over the new inserted instruction
+// and do not disturb the program flow.
+func findInsertAfter(jumps []Jump, currentJump Jump) Jump {
+	insertAfter := currentJump
+	maxIndex := currentJump.index + 255
+	for _, jump := range jumps {
+		if jump.index < maxIndex {
+			insertAfter = jump
+		}
+	}
+	return insertAfter
+}
+
+// Calculate the index of the current instruction.
+func (p *Program) currentIndex() Index {
+	return Index(len(p.instructions))
+}

--- a/assembler.go
+++ b/assembler.go
@@ -145,6 +145,7 @@ func (p *Program) NewLabel() Label {
 // This method takes care of long jumps and resolves them by using early returns or unconditional long jumps.
 func (p *Program) Assemble() ([]bpf.Instruction, error) {
 	for _, jump := range p.jumps {
+		// This is safe since we are only accessing instructions that were inserted as bpf.JumpIf.
 		jumpInst := p.instructions[jump.index].(bpf.JumpIf)
 
 		skip, err := p.resolveLabel(jump, jump.trueLabel)

--- a/cmd/sandbox/seccomp.yml
+++ b/cmd/sandbox/seccomp.yml
@@ -25,3 +25,12 @@ seccomp:
     - recvmsg
     - bind
     - listen
+  # System Call Argument Filtering examples.
+  # CLONE_NEWUSER must be set.
+  - action: errno
+    names_with_args:
+    - name: clone
+      arguments: 
+      - argument: 0
+        operation: BitsNotSet
+        value: 0x10000000 

--- a/filter.go
+++ b/filter.go
@@ -135,7 +135,7 @@ type SyscallGroup struct {
 type ArgumentConditions []Condition
 
 func (a ArgumentConditions) Validate() []string {
-	problems := make([]string, 0)
+	var problems []string
 	for _, condition := range a {
 		if condition.Argument < 0 || condition.Argument > 5 {
 			problems = append(problems, fmt.Sprintf("argument must be between 0 and 5 (inclusive), but is %v", condition.Argument))
@@ -283,10 +283,9 @@ type SyscallWithConditions struct {
 // getSyscall searches the syscall in the list.
 // Do not use a map to keep the ordering, as specified by the user.
 func getSyscall(syscalls []SyscallWithConditions, syscall uint32) *SyscallWithConditions {
-	for i := 0; i < len(syscalls); i++ {
-		s := &syscalls[i]
+	for _, s := range syscalls {
 		if s.Num == syscall {
-			return s
+			return &s
 		}
 	}
 	return nil
@@ -294,10 +293,10 @@ func getSyscall(syscalls []SyscallWithConditions, syscall uint32) *SyscallWithCo
 
 // toSyscallsWithConditions transforms a syscall group to syscalls with conditions.
 func (g *SyscallGroup) toSyscallsWithConditions() ([]SyscallWithConditions, error) {
-	var problems []string
-
-	syscalls := make([]SyscallWithConditions, 0)
-
+	var (
+		syscalls []SyscallWithConditions
+		problems []string
+	)
 	for _, name := range g.Names {
 		if num, found := g.arch.SyscallNames[name]; found {
 			syscall := uint32(num | g.arch.SeccompMask)
@@ -322,8 +321,7 @@ func (g *SyscallGroup) toSyscallsWithConditions() ([]SyscallWithConditions, erro
 				continue
 			}
 			if check == nil {
-				conditions := make([]ArgumentConditions, 0)
-				conditions = append(conditions, nc.Conditions)
+				conditions := []ArgumentConditions{nc.Conditions}
 				syscalls = append(syscalls, SyscallWithConditions{Num: syscall, Conditions: conditions})
 			} else {
 				if len(check.Conditions) == 0 {

--- a/filter.go
+++ b/filter.go
@@ -368,7 +368,7 @@ func (g *SyscallGroup) Assemble(defaultAction Action) ([]bpf.Instruction, error)
 	p.SetLabel(action)
 	p.Ret(g.Action)
 
-	return p.Assemble(), nil
+	return p.Assemble()
 }
 
 func (s SyscallWithConditions) Assemble(p *Program, action Label) {

--- a/filter.go
+++ b/filter.go
@@ -124,10 +124,63 @@ type Policy struct {
 // SyscallGroup is a logical block within a Policy that contains a set of
 // syscalls to match against and an action to take.
 type SyscallGroup struct {
-	Names  []string `config:"names"  validate:"required" json:"names"  yaml:"names"`  // List of syscall names (all must exist).
-	Action Action   `config:"action" validate:"required" json:"action" yaml:"action"` // Action to take upon a match.
+	Names              []string             `config:"names"  json:"names"  yaml:"names"`                              // List of syscall names (all must exist).
+	NamesWithCondtions []NameWithConditions `config:"names_with_args" json:"names_with_args"  yaml:"names_with_args"` // List of syscall with argument filters
+	Action             Action               `config:"action" validate:"required" json:"action" yaml:"action"`         // Action to take upon a match.
 
 	arch *arch.Info
+}
+
+// ArgumentConditions consist of a list of up to six conditions for the six arguments.
+type ArgumentConditions []Condition
+
+func (a ArgumentConditions) Validate() []string {
+	problems := make([]string, 0)
+	for _, condition := range a {
+		if condition.Argument < 0 || condition.Argument > 5 {
+			problems = append(problems, fmt.Sprintf("argument must be between 0 and 5 (inclusive), but is %v", condition.Argument))
+		}
+	}
+	return problems
+}
+
+type NameWithConditions struct {
+	Name       string             `config:"name" validate:"required" json:"name"  yaml:"name"`
+	Conditions ArgumentConditions `config:"arguments" validate:"required" json:"arguments"  yaml:"arguments"`
+}
+
+type Condition struct {
+	Argument  int       `config:"argument" default:"0" json:"position"  yaml:"position"`
+	Operation Operation `config:"operation" validate:"required" json:"operation"  yaml:"operation"`
+	Value     uint64    `config:"value" default:"0" json:"value"  yaml:"value"`
+}
+
+type Operation string
+
+const (
+	Equal          Operation = "Equal"
+	NotEqual       Operation = "NotEqual"
+	GreaterThan    Operation = "GreaterThan"
+	LessThan       Operation = "LessThan"
+	GreaterOrEqual Operation = "GreaterOrEqual"
+	LessOrEqual    Operation = "LessOrEqual"
+	BitsSet        Operation = "BitsSet"
+	BitsNotSet     Operation = "BitsNotSet"
+)
+
+var Operations = []Operation{Equal, NotEqual, GreaterThan, LessThan, GreaterOrEqual, LessOrEqual, BitsSet, BitsNotSet}
+
+// Unpack sets the Operation value based on the string.
+func (o *Operation) Unpack(s string) error {
+	s = strings.ToLower(s)
+	for _, name := range Operations {
+		if strings.ToLower(string(name)) == s {
+			*o = name
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid operation: %v", s)
 }
 
 // Validate validates that the configuration has both a default action and a
@@ -160,12 +213,6 @@ func (p *Policy) Assemble() ([]bpf.Instruction, error) {
 		p.arch = arch
 	}
 
-	// Setup the action.
-	action := p.DefaultAction
-	if action == ActionErrno {
-		action |= Action(errnoEPERM)
-	}
-
 	// Build the syscall filters.
 	var instructions []bpf.Instruction
 	for _, group := range p.Syscalls {
@@ -173,7 +220,7 @@ func (p *Policy) Assemble() ([]bpf.Instruction, error) {
 			group.arch = p.arch
 		}
 
-		groupInsts, err := group.Assemble()
+		groupInsts, err := group.Assemble(p.DefaultAction)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +242,7 @@ func (p *Policy) Assemble() ([]bpf.Instruction, error) {
 	program = append(program, bpf.LoadAbsolute{Off: archOffset, Size: 4})
 
 	// If the loaded arch ID is not equal p.arch.ID, jump to the final Ret instruction.
-	jumpN := 1 + len(x32Filter) + len(instructions)
+	jumpN := len(x32Filter) + len(instructions) - 1
 	if jumpN <= 255 {
 		program = append(program, bpf.JumpIf{Cond: bpf.JumpNotEqual, Val: uint32(p.arch.ID), SkipTrue: uint8(jumpN)})
 	} else {
@@ -207,7 +254,6 @@ func (p *Policy) Assemble() ([]bpf.Instruction, error) {
 	program = append(program, bpf.LoadAbsolute{Off: syscallNumOffset, Size: 4})
 	program = append(program, x32Filter...)
 	program = append(program, instructions...)
-	program = append(program, bpf.RetConstant{Val: uint32(action)})
 	return program, nil
 }
 
@@ -224,55 +270,187 @@ func (p *Policy) Dump(out io.Writer) error {
 	return nil
 }
 
-// Assemble assembles the policy into a list of BPF instructions. If the group
-// contains any unknown syscalls or invalid actions an error will be returned.
-func (g *SyscallGroup) Assemble() ([]bpf.Instruction, error) {
-	if len(g.Names) == 0 {
+// SyscallWithConditions consists of a syscall number and optional conditions.
+//
+// The conditions are applied to the arguments of the syscall.
+// So, conditions consist of a list of up to six argument conditions.
+// This filter matches if all argument conditions match for any Conditions.
+type SyscallWithConditions struct {
+	Num        uint32
+	Conditions []ArgumentConditions
+}
+
+// getSyscall searches the syscall in the list.
+// Do not use a map to keep the ordering, as specified by the user.
+func getSyscall(syscalls []SyscallWithConditions, syscall uint32) *SyscallWithConditions {
+	for i := 0; i < len(syscalls); i++ {
+		s := &syscalls[i]
+		if s.Num == syscall {
+			return s
+		}
+	}
+	return nil
+}
+
+// toSyscallsWithConditions transforms a syscall group to syscalls with conditions.
+func (g *SyscallGroup) toSyscallsWithConditions() ([]SyscallWithConditions, error) {
+	var problems []string
+
+	syscalls := make([]SyscallWithConditions, 0)
+
+	for _, name := range g.Names {
+		if num, found := g.arch.SyscallNames[name]; found {
+			syscall := uint32(num | g.arch.SeccompMask)
+			if getSyscall(syscalls, syscall) == nil {
+				syscalls = append(syscalls, SyscallWithConditions{Num: syscall})
+			} else {
+				problems = append(problems, fmt.Sprintf("found duplicate syscall %v", name))
+			}
+		} else {
+			problems = append(problems, fmt.Sprintf("found unknown syscalls for arch %v: %v", g.arch.Name, name))
+		}
+	}
+
+	for _, nc := range g.NamesWithCondtions {
+		if num, found := g.arch.SyscallNames[nc.Name]; found {
+			syscall := uint32(num | g.arch.SeccompMask)
+			check := getSyscall(syscalls, syscall)
+
+			invalidArguments := nc.Conditions.Validate()
+			if len(invalidArguments) > 0 {
+				problems = append(problems, invalidArguments...)
+				continue
+			}
+			if check == nil {
+				conditions := make([]ArgumentConditions, 0)
+				conditions = append(conditions, nc.Conditions)
+				syscalls = append(syscalls, SyscallWithConditions{Num: syscall, Conditions: conditions})
+			} else {
+				if len(check.Conditions) == 0 {
+					// Unconditional check found.
+					problems = append(problems, fmt.Sprintf("found conditional and unconditional check: %v", nc.Name))
+				} else {
+					check.Conditions = append(check.Conditions, nc.Conditions)
+				}
+			}
+		} else {
+			problems = append(problems, fmt.Sprintf("found unknown syscalls for arch %v: %v", g.arch.Name, nc.Name))
+		}
+	}
+
+	if len(problems) > 0 {
+		return nil, fmt.Errorf(strings.Join(problems, "\n"))
+	}
+
+	return syscalls, nil
+}
+
+func (g *SyscallGroup) Assemble(defaultAction Action) ([]bpf.Instruction, error) {
+	if len(g.Names) == 0 && len(g.NamesWithCondtions) == 0 {
 		return nil, nil
 	}
 
 	// Validate the syscalls.
-	var unknowns []string
-	var syscallNums []uint32
-	for _, name := range g.Names {
-		if num, found := g.arch.SyscallNames[name]; found {
-			syscallNums = append(syscallNums, uint32(num|g.arch.SeccompMask))
-		} else {
-			unknowns = append(unknowns, name)
-		}
-	}
-	if len(unknowns) > 0 {
-		return nil, fmt.Errorf("found unknown syscalls for arch %v: %v",
-			g.arch.Name, strings.Join(unknowns, ","))
+	syscalls, err := g.toSyscallsWithConditions()
+	if err != nil {
+		return nil, err
 	}
 
-	insts := make([]bpf.Instruction, 0, len(syscallNums))
+	p := NewProgram()
 
-	for len(syscallNums) > 0 {
-		// JumpIf can not handle long jumps, so we insert a Ret after each group of 256 checks.
-		size := len(syscallNums)
-		if size > 256 {
-			size = 256
-		}
-		syscallNums256 := syscallNums[:size]
-		syscallNums = syscallNums[size:]
+	action := p.NewLabel()
+	for _, syscall := range syscalls {
+		syscall.Assemble(&p, action)
+	}
 
-		for i, num := range syscallNums256 {
-			jumpN := uint8(len(syscallNums256) - i - 1)
-			jeq := bpf.JumpIf{Cond: bpf.JumpEqual, Val: num, SkipTrue: jumpN}
-			if jumpN == 0 {
-				// Skip the return statement if the last condition was not satisfied.
-				jeq.SkipFalse = 1
+	p.Ret(defaultAction)
+
+	p.SetLabel(action)
+	p.Ret(g.Action)
+
+	return p.Assemble(), nil
+}
+
+func (s SyscallWithConditions) Assemble(p *Program, action Label) {
+	if len(s.Conditions) == 0 {
+		// If no conditions are set, compare to the syscall number and jump to action if it matches.
+		p.JmpIfTrue(bpf.JumpEqual, s.Num, action)
+		return
+	}
+
+	nextSyscall := p.NewLabel()
+	p.JmpIfTrue(bpf.JumpNotEqual, s.Num, nextSyscall)
+
+	for _, conditions := range s.Conditions {
+		noMatch := p.NewLabel()
+		for i, c := range conditions {
+			nextArgument := p.NewLabel()
+
+			// All argument checks must match, so if this argument check matches, jump to the next argument
+			// or if it is the last check to the action.
+			match := nextArgument
+			isLast := i == len(conditions)-1
+			if isLast {
+				match = action
 			}
-			insts = append(insts, jeq)
-		}
 
-		action := g.Action
-		if action == ActionErrno {
-			action |= Action(errnoEPERM)
+			// Perform the 64-bit operation with multiple 32-bit operations.
+			if c.Operation == Equal {
+				// Arg_hi == Val_hi && Arg_lo == Val_lo
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpEqual, uint32(c.Value), match, noMatch)
+			} else if c.Operation == NotEqual {
+				// Arg_hi != Val_hi || Arg_lo != Val_lo
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), match)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpNotEqual, uint32(c.Value), match, noMatch)
+			} else if c.Operation == GreaterThan {
+				// Arg_hi > Val_hi || (Arg_hi == Val_hi && Arg_lo > Val_lo)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpGreaterThan, uint32(c.Value>>32), match)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpGreaterThan, uint32(c.Value), match, noMatch)
+			} else if c.Operation == GreaterOrEqual {
+				// Arg_hi >= Val_hi || (Arg_hi == Val_hi && Arg_lo >= Val_lo)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpGreaterThan, uint32(c.Value>>32), match)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpGreaterOrEqual, uint32(c.Value), match, noMatch)
+			} else if c.Operation == LessThan {
+				// Arg_hi < Val_hi || (Arg_hi == Val_hi && Arg_lo < Val_lo)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpLessThan, uint32(c.Value>>32), match)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpLessThan, uint32(c.Value), match, noMatch)
+			} else if c.Operation == LessOrEqual {
+				// Arg_hi <= Val_hi || (Arg_hi == Val_hi && Arg_lo <= Val_lo)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpLessThan, uint32(c.Value>>32), match)
+				p.JmpIfTrue(bpf.JumpNotEqual, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpLessOrEqual, uint32(c.Value), match, noMatch)
+			} else if c.Operation == BitsSet {
+				// (Arg_hi & Val_hi == 0) || (Arg_lo & Val_lo == 0)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpBitsSet, uint32(c.Value>>32), match)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpBitsSet, uint32(c.Value), match, noMatch)
+			} else if c.Operation == BitsNotSet {
+				// (Arg_hi & Val_hi != 0) && (Arg_lo & Val_lo != 0)
+				p.LdHi(c.Argument)
+				p.JmpIfTrue(bpf.JumpBitsSet, uint32(c.Value>>32), noMatch)
+				p.LdLo(c.Argument)
+				p.JmpIf(bpf.JumpBitsNotSet, uint32(c.Value), match, noMatch)
+			}
+			p.SetLabel(nextArgument)
 		}
-		insts = append(insts, bpf.RetConstant{Val: uint32(action)})
+		p.SetLabel(noMatch)
 	}
-
-	return insts, nil
+	p.SetLabel(nextSyscall)
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -464,12 +464,14 @@ func TestLongConditions(t *testing.T) {
 			ActionKillThread,
 		},
 		{
-			SeccompData{NR: 1, Arch: uint32(arch.X86_64.ID), Args: [6]uint64{lastCheck,
+			SeccompData{NR: 1, Arch: uint32(arch.X86_64.ID), Args: [6]uint64{
+				lastCheck,
 				lastCheck + 1,
 				lastCheck + 2,
 				lastCheck + 3,
 				lastCheck + 4,
-				lastCheck + 5}},
+				lastCheck + 5,
+			}},
 			ActionKillThread,
 		},
 		{

--- a/filter_test.go
+++ b/filter_test.go
@@ -276,7 +276,6 @@ func TestPolicyAssembleDefault(t *testing.T) {
 }
 
 func TestSimpleLongList(t *testing.T) {
-
 	syscallNumbers := make([]int, 0, len(arch.X86_64.SyscallNumbers))
 	for nr := range arch.X86_64.SyscallNumbers {
 		syscallNumbers = append(syscallNumbers, nr)
@@ -287,7 +286,6 @@ func TestSimpleLongList(t *testing.T) {
 	for i := 1; i < 6; i++ {
 		names = append(names, arch.X86_64.SyscallNumbers[i])
 	}
-
 	names = append(names, "read")
 
 	policy := &Policy{
@@ -314,7 +312,6 @@ func TestSimpleLongList(t *testing.T) {
 }
 
 func TestSimpleConditions(t *testing.T) {
-
 	for _, tc := range conditionTests {
 		t.Run(string(tc.cond), func(t *testing.T) {
 			policy := &Policy{
@@ -397,8 +394,7 @@ func TestTwoArgumentConditions(t *testing.T) {
 				policy.Dump(os.Stdout)
 			}
 
-			syscalls := make([]SeccompTest, 0)
-
+			syscalls := make([]SeccompTest, 0, len(conditionInput))
 			for _, arg1 := range conditionInput {
 				for _, arg2 := range conditionInput {
 					expected := ActionAllow
@@ -423,11 +419,10 @@ func TestTwoArgumentConditions(t *testing.T) {
 // https://github.com/seccomp/libseccomp/blob/main/src/arch.c#L287
 
 func TestLongConditions(t *testing.T) {
-
-	filter := make([]NameWithConditions, 0)
+	filter := make([]NameWithConditions, 0, 20)
 	for i := uint64(0); i < 20; i++ {
 
-		arguments := make([]Condition, 0)
+		arguments := make([]Condition, 0, 6)
 		for arg := 0; arg < 6; arg++ {
 			argument := Condition{
 				Argument:  arg,

--- a/filter_test.go
+++ b/filter_test.go
@@ -101,8 +101,10 @@ var conditionTests = []struct {
 	{cond: BitsNotSet, eval: func(input, policy uint64) bool { return input&policy == 0 }},
 }
 
-var testArgument1 uint64 = 0x0102_0304_0506_0708
-var testArgument2 uint64 = 0x1020_3040_5060_7080
+const (
+	testArgument1 = 0x0102_0304_0506_0708
+	testArgument2 = 0x1020_3040_5060_7080
+)
 
 // hand crafted conditionInput to test the 64-bit operations.
 var conditionInput = []uint64{


### PR DESCRIPTION
This pull request implements argument filtering and closes #1.

The changes are backward-compatible. The configuration can be added under the key `names_with_args` to the YAML-file or with the struct `NameWithConditions` directly in the code.

```
  - action: errno
    names_with_args:
    - name: clone
      arguments: 
      - argument: 0
        operation: BitsNotSet
        value: 0x10000000
```

```
NamesWithCondtions: []NameWithConditions{
	{
		Name: "read",
		Conditions: []Condition{
			{
				Argument:  0,
				Operation: Equal,
				Value:     0x0102_0304_0506_0708,
			},
		},
	},
},
```