### PR TITLE
Update syscalls for Linux 6.6

### DIFF
--- a/arch/mk_syscalls_linux.go
+++ b/arch/mk_syscalls_linux.go
@@ -394,7 +394,7 @@ var (
 
 func init() {
 	flag.StringVar(&outputFile, "out", "zsyscalls.go", "output file")
-	flag.StringVar(&linuxVersion, "version", "v6.5", "linux version (git tag)")
+	flag.StringVar(&linuxVersion, "version", "v6.6", "linux version (git tag)")
 }
 
 func main() {

--- a/arch/zsyscalls.go
+++ b/arch/zsyscalls.go
@@ -19,7 +19,7 @@
 
 package arch
 
-// Based on Linux v6.5.
+// Based on Linux v6.6.
 
 var syscallsARM = map[int]string{
 	0:      "restart_syscall",
@@ -426,6 +426,7 @@ var syscallsARM = map[int]string{
 	449:    "futex_waitv",
 	450:    "set_mempolicy_home_node",
 	451:    "cachestat",
+	452:    "fchmodat2",
 	983041: "breakpoint",
 	983042: "cacheflush",
 	983043: "usr26",
@@ -763,6 +764,7 @@ var syscallsAARCH64 = map[int]string{
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
 	451: "cachestat",
+	452: "fchmodat2",
 }
 
 var syscalls386 = map[int]string{
@@ -1207,6 +1209,7 @@ var syscalls386 = map[int]string{
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
 	451: "cachestat",
+	452: "fchmodat2",
 }
 
 var syscallsX32 = map[int]string{
@@ -1573,6 +1576,8 @@ var syscallsX32 = map[int]string{
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
 	451: "cachestat",
+	452: "fchmodat2",
+	453: "map_shadow_stack",
 	512: "rt_sigaction",
 	513: "rt_sigreturn",
 	514: "ioctl",
@@ -1975,4 +1980,6 @@ var syscallsX86_64 = map[int]string{
 	449: "futex_waitv",
 	450: "set_mempolicy_home_node",
 	451: "cachestat",
+	452: "fchmodat2",
+	453: "map_shadow_stack",
 }


### PR DESCRIPTION
Updated with:

`docker run -v $(pwd):/go-seccomp-bpf -it --rm -w /go-seccomp-bpf/arch golang:1.21 go generate`