### PR TITLE
chore: update mk_syscalls_linux to v6.14

### DIFF
--- a/arch/mk_syscalls_linux.go
+++ b/arch/mk_syscalls_linux.go
@@ -394,7 +394,7 @@ var (
 
 func init() {
 	flag.StringVar(&outputFile, "out", "zsyscalls.go", "output file")
-	flag.StringVar(&linuxVersion, "version", "v6.13", "linux version (git tag)")
+	flag.StringVar(&linuxVersion, "version", "v6.14", "linux version (git tag)")
 }
 
 func main() {

--- a/arch/zsyscalls.go
+++ b/arch/zsyscalls.go
@@ -19,7 +19,7 @@
 
 package arch
 
-// Based on Linux v6.13.
+// Based on Linux v6.14.
 
 var syscallsARM = map[int]string{
 	0:      "restart_syscall",


### PR DESCRIPTION
No new syscalls on this kernel release, just updating the kernel version.