### PR TITLE
fix(filter.go): continue to next syscall group on no match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a control flow bug in the filter when multiple syscall groups are defined. [#40](https://github.com/elastic/go-seccomp-bpf/issues/40)
+
 ### Security
 
 ## [1.5.0] - 2024-11-06

--- a/filter_test.go
+++ b/filter_test.go
@@ -138,19 +138,19 @@ func TestPolicyAssembleBlacklist(t *testing.T) {
 
 	simulateSyscalls(t, policy, []SeccompTest{
 		{
-			SeccompData{NR: 59, Arch: uint32(arch.X86_64.ID)},
+			SeccompData{NR: 59 /* execve */, Arch: uint32(arch.X86_64.ID)},
 			ActionKillThread,
 		},
 		{
-			SeccompData{NR: 57, Arch: uint32(arch.X86_64.ID)},
+			SeccompData{NR: 57 /* fork */, Arch: uint32(arch.X86_64.ID)},
 			ActionKillThread,
 		},
 		{
-			SeccompData{NR: 4, Arch: uint32(arch.X86_64.ID)},
+			SeccompData{NR: 4 /* stat */, Arch: uint32(arch.X86_64.ID)},
 			ActionAllow,
 		},
 		{
-			SeccompData{NR: 4, Arch: uint32(arch.ARM.ID)},
+			SeccompData{NR: 4 /* write */, Arch: uint32(arch.ARM.ID)},
 			ActionAllow,
 		},
 		{
@@ -184,15 +184,23 @@ func TestPolicyAssembleWhitelist(t *testing.T) {
 
 	simulateSyscalls(t, policy, []SeccompTest{
 		{
-			SeccompData{NR: 59, Arch: uint32(arch.X86_64.ID)},
+			SeccompData{NR: 59 /* execve */, Arch: uint32(arch.X86_64.ID)},
 			ActionAllow,
 		},
 		{
-			SeccompData{NR: 4, Arch: uint32(arch.X86_64.ID)},
+			SeccompData{NR: 57 /* fork */, Arch: uint32(arch.X86_64.ID)},
+			ActionAllow,
+		},
+		{
+			SeccompData{NR: 56 /* clone */, Arch: uint32(arch.X86_64.ID)},
+			ActionAllow,
+		},
+		{
+			SeccompData{NR: 4 /* write */, Arch: uint32(arch.X86_64.ID)},
 			ActionKillProcess,
 		},
 		{
-			SeccompData{NR: 4, Arch: uint32(arch.ARM.ID)},
+			SeccompData{NR: 4 /* write */, Arch: uint32(arch.ARM.ID)},
 			ActionKillProcess,
 		},
 	})


### PR DESCRIPTION
When #28 introduced syscall argument matching, it also added a bug where the default action was executed if the first syscall group did not match. This meant that none of the subsequent syscall groups were evaluated. So the filter would either match something in the first group and return the group's action or return the default action.

Here is an annotated version of a filter before this fix.

    0: ld [4]                 # Load arch field from seccomp_data
    1: jneq #3221225534,9     # If arch != AUDIT_ARCH_X86_64, jump to 11
    2: ld [0]                 # Load syscall nr from seccomp_data
    3: jlt #1073741824,1      # If syscall < 1073741824, jump to 5
    4: ret #327718            # Return SECCOMP_RET_ERRNO | 6 (EPERM)
    5: jeq #59,2              # If syscall == execve, jump to 8
    6: jeq #57,1              # If syscall == fork, jump to 8
    7: ret #2147483648        # Return SECCOMP_RET_KILL_PROCESS
    8: ret #2147418112        # Return SECCOMP_RET_ALLOW
    9: jeq #56,2              # If syscall == clone, jump to 12
    10: jeq #50,1             # If syscall == open, jump to 12
    11: ret #2147483648       # Return SECCOMP_RET_KILL_PROCESS
    12: ret #2147418112       # Return SECCOMP_RET_ALLOW

With this fix in place the same policy becomes:

    0: ld [4]                 # Load arch field from seccomp_data
    1: jneq #3221225534,9     # If arch != AUDIT_ARCH_X86_64, jump to 11
    2: ld [0]                 # Load syscall nr from seccomp_data
    3: jlt #1073741824,1      # If syscall < 1073741824, jump to 5
    4: ret #327718            # Return SECCOMP_RET_ERRNO | 6 (EPERM)
    5: jeq #59,1              # If syscall == execve, jump to 7
    6: jneq #57,1             # If syscall != fork, jump to 8
    7: ret #2147418112        # Return SECCOMP_RET_ALLOW
    8: jeq #56,1              # If syscall == clone, jump to 10
    9: jneq #50,1             # If syscall != open, jump to 11
    10: ret #2147418112       # Return SECCOMP_RET_ALLOW
    11: ret #2147483648       # Return SECCOMP_RET_KILL_PROCESS

Fixes #40