### PR TITLE
chore: update linux syscall table based on v6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update syscall table based on linux v6.16. [52](https://github.com/elastic/go-seccomp-bpf/pull/52)
 - Update syscall table based on linux v6.17. [55](https://github.com/elastic/go-seccomp-bpf/pull/55)
 - Update syscall table based on linux v6.18. [57](https://github.com/elastic/go-seccomp-bpf/pull/57)
+- Update syscall table based on linux v6.19. [58](https://github.com/elastic/go-seccomp-bpf/pull/58)
 
 ### Deprecated
 

--- a/arch/mk_syscalls_linux.go
+++ b/arch/mk_syscalls_linux.go
@@ -394,7 +394,7 @@ var (
 
 func init() {
 	flag.StringVar(&outputFile, "out", "zsyscalls.go", "output file")
-	flag.StringVar(&linuxVersion, "version", "v6.18", "linux version (git tag)")
+	flag.StringVar(&linuxVersion, "version", "v6.19", "linux version (git tag)")
 }
 
 func main() {

--- a/arch/zsyscalls.go
+++ b/arch/zsyscalls.go
@@ -19,7 +19,7 @@
 
 package arch
 
-// Based on Linux v6.18.
+// Based on Linux v6.19.
 
 var syscallsARM = map[int]string{
 	0:      "restart_syscall",
@@ -444,6 +444,7 @@ var syscallsARM = map[int]string{
 	467:    "open_tree_attr",
 	468:    "file_getattr",
 	469:    "file_setattr",
+	470:    "listns",
 	983041: "breakpoint",
 	983042: "cacheflush",
 	983043: "usr26",
@@ -799,6 +800,7 @@ var syscallsAARCH64 = map[int]string{
 	467: "open_tree_attr",
 	468: "file_getattr",
 	469: "file_setattr",
+	470: "listns",
 }
 
 var syscalls386 = map[int]string{
@@ -1261,6 +1263,7 @@ var syscalls386 = map[int]string{
 	467: "open_tree_attr",
 	468: "file_getattr",
 	469: "file_setattr",
+	470: "listns",
 }
 
 var syscallsX32 = map[int]string{
@@ -1647,6 +1650,7 @@ var syscallsX32 = map[int]string{
 	467: "open_tree_attr",
 	468: "file_getattr",
 	469: "file_setattr",
+	470: "listns",
 	512: "rt_sigaction",
 	513: "rt_sigreturn",
 	514: "ioctl",
@@ -2069,4 +2073,5 @@ var syscallsX86_64 = map[int]string{
 	467: "open_tree_attr",
 	468: "file_getattr",
 	469: "file_setattr",
+	470: "listns",
 }


### PR DESCRIPTION
Linux v6.19 released on Feb 8 2026 with a new `listns` system call.