### PR TITLE
seccomp-profiler: bail out early on (unsupported) "arm" architecture

### DIFF
--- a/cmd/seccomp-profiler/main.go
+++ b/cmd/seccomp-profiler/main.go
@@ -191,12 +191,10 @@ func getBinaryArch(binary string) (*arch.Info, string, error) {
 	switch bin.Machine {
 	case elf.EM_386:
 		return arch.I386, "386", nil
-	case elf.EM_ARM:
-		return arch.ARM, "arm", nil
 	case elf.EM_X86_64:
 		return arch.X86_64, "amd64", nil
 	default:
-		return nil, "", fmt.Errorf("%v architecture is not supported by go-seccomp-bpf", bin.Machine)
+		return nil, "", fmt.Errorf("%v architecture is not supported by seccomp-profiler", bin.Machine)
 	}
 }
 


### PR DESCRIPTION
There's little point in doing the object dump only to
later (in ExtractSyscalls) find out we don't handle it.

Also, say 'seccomp-profiler' rather than 'go-seccomp-bpf' in
the error message, as the architecture support of the former
is independent from the latter.