### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,6 @@ metadata:
 
 spec:
   type: library
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,6 @@ metadata:
 
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production


### PR DESCRIPTION
This catches up catalog-info.yaml to the GitHub team's actual current name — the `ingest-fp` team was renamed to `Streams`, and these stale references now match.